### PR TITLE
Prepare for new metadata collection scheme

### DIFF
--- a/src/act/ldmx/scripts/ldmx-simprod-rte-helper.py
+++ b/src/act/ldmx/scripts/ldmx-simprod-rte-helper.py
@@ -114,6 +114,16 @@ def calculate_md5_adler32_checksum(file, chunk_size=524288):
             adler32 = zlib.adler32(chunk, adler32) & 0xffffffff
     return (md5.hexdigest(), '{:08x}'.format(adler32))
 
+def job_starttime(starttime_f='.ldmx.job.starttime'):
+    if os.path.exists(starttime_f):
+        with open(starttime_f, 'r') as fd:
+            return int(fd.read())
+    else:
+        current_time = int(time.time())
+        with open(starttime_f, 'w') as fd:
+            fd.write('{0}'.format(current_time))
+            return current_time
+        
 
 def collect_from_json( infile ):
     #function to convert json nested list to flat metadata list 

--- a/src/act/ldmx/scripts/ldmx-simprod-rte-helper.py
+++ b/src/act/ldmx/scripts/ldmx-simprod-rte-helper.py
@@ -50,8 +50,8 @@ def parse_ldmx_config(config='ldmxjob.config'):
         logger.error('PhysicsProcess is not defined in the %s. Job aborted.', config)
         sys.exit(1)
     # ensure both random seeds are set
-    if 'RandomSeed1' in conf_dict and 'RandomSeed2' not in conf_dict:
-        logger.error('RandomSeed1 is set without RandomSeed2 in %s. Job aborted.', config)
+    if 'RandomSeed1' not in conf_dict or 'RandomSeed2' not in conf_dict:
+        logger.error('RandomSeed1 and/or RandomSeed2 is not set in %s. Job aborted.', config)
         sys.exit(1)
     # mandatory options
     for opt in ['DetectorVersion', 'FieldMap']:
@@ -115,10 +115,113 @@ def calculate_md5_adler32_checksum(file, chunk_size=524288):
     return (md5.hexdigest(), '{:08x}'.format(adler32))
 
 
+def collect_from_json( infile ):
+    #function to convert json nested list to flat metadata list 
+    config_dict = {}
+    with open(infile, "r") as jf :
+        mjson = json.load(jf) 
+
+#    mjson = json.loads( infile )
+    if not mjson :
+        print "trouble"
+    else :
+        print "opened "+infile
+    config_dict['GunPositionX'] = mjson['sequence'][0]['generators'][0]['position'][0]
+    config_dict['GunPositionY'] = mjson['sequence'][0]['generators'][0]['position'][1]
+    config_dict['GunPositionZ'] = mjson['sequence'][0]['generators'][0]['position'][2]
+    config_dict['GunDirectionX'] = mjson['sequence'][0]['generators'][0]['direction'][0]
+    config_dict['GunDirectionY'] = mjson['sequence'][0]['generators'][0]['direction'][1]
+    config_dict['GunDirectionZ'] = mjson['sequence'][0]['generators'][0]['direction'][2]
+    config_dict['BeamSpotSizeX'] = mjson['sequence'][0]['beamSpotSmear'][0]
+    config_dict['BeamSpotSizeY'] = mjson['sequence'][0]['beamSpotSmear'][1]
+    config_dict['BeamSpotSizeZ'] = mjson['sequence'][0]['beamSpotSmear'][2]
+    config_dict['BeamEnergy'] = mjson['sequence'][0]['generators'][0]['energy']
+    config_dict['BeamParticle'] = mjson['sequence'][0]['generators'][0]['particle']
+    config_dict['RandomSeed1'] = mjson['sequence'][0]['randomSeeds'][0]
+    config_dict['RandomSeed2'] = mjson['sequence'][0]['randomSeeds'][1]
+    for params in mjson['sequence'][0]['actions'] :
+#        print params
+        p = params['class_name']
+        key=p.replace("ldmx::", "")
+#        print key
+        for k, val in params.iteritems() :
+            if 'threshold' in k :
+                keepKey=key+"_"+k
+#                print k
+                config_dict[keepKey]=val
+
+                
+    config_dict['ROOTCompressionSetting'] = mjson['compressionSetting']
+                
+    config_dict['Geant4BiasParticle'] = mjson['sequence'][0]['biasing_particle']
+    config_dict['Geant4BiasProcess'] = mjson['sequence'][0]['biasing_process']
+    config_dict['Geant4BiasVolume'] = mjson['sequence'][0]['biasing_volume']
+    config_dict['Geant4BiasThreshold'] = mjson['sequence'][0]['biasing_threshold']
+    config_dict['Geant4BiasFactor'] = mjson['sequence'][0]['biasing_factor']
+    config_dict['APrimeMass'] = mjson['sequence'][0]['APrimeMass']
+    config_dict['DarkBremMethod'] = mjson['sequence'][0]['darkbrem_method']
+    config_dict['DarkBremMethodXsecFactor'] = mjson['sequence'][0]['darkbrem_globalxsecfactor']
+
+
+    #ok. over reco stuff, where names can get confusing.
+
+    isRecon = False 
+    for seq in mjson['sequence'] :
+#        print seq
+        if seq['className'] != "ldmx::Simulator" :  #everything except simulation is reconstruction
+            isRecon = True 
+        if seq['className'] == "ldmx::EcalDigiProducer" :
+            config_dict['EcalDigiGain'] = seq['gain']
+            config_dict['EcalDigiPedestal'] = seq['pedestal']
+            config_dict['EcalDigiNoiseIntercept'] = seq['noiseIntercept']
+            config_dict['EcalDigiNoiseSlope'] = seq['noiseSlope']
+            config_dict['EcalDigiPadCapacitance'] = seq['padCapacitance']
+            config_dict['EcalDigiReadoutThreshold'] = seq['readoutThreshold']
+        elif seq['className'] == "ldmx::EcalVetoProcessor" :
+            config_dict['EcalLayers'] = seq['num_ecal_layers']
+            config_dict['EcalDiscriminatorCut'] = seq['disc_cut']
+        elif seq['className'] == "ldmx::HcalVetoProcessor" :
+            config_dict['HcalVetoMaxPE'] = seq['pe_threshold']
+            config_dict['HcalVetoMaxTime'] = seq['max_time']
+            config_dict['HcalVetoMaxDepth'] = seq['max_depth']
+            config_dict['HcalVetoBackMinPE'] = seq['back_min_pe']
+        elif seq['className'] == "ldmx::HcalDigiProducer" :
+            config_dict['HcalMeanNoiseSiPM'] = seq['meanNoise']
+            config_dict['HcalMeVPerMIP'] = seq['mev_per_mip']
+            config_dict['HcalPEPerMIP'] = seq['pe_per_mip']
+            config_dict['HcalAttLength'] = seq['strip_attenuation_length']
+            config_dict['HcalPosResolution'] = seq['strip_position_resolution']
+
+        elif seq['className'] == "ldmx::TrigScintDigiProducer" :
+            config_dict['TrigScintMeanNoiseSiPM'] = seq['mean_noise']
+            config_dict['TrigScintMeVPerMIP'] = seq['mev_per_mip']
+            config_dict['TrigScintPEPerMIP'] = seq['pe_per_mip']
+
+        elif seq['className'] == "ldmx::TrackerHitKiller" :
+            config_dict['TrackKillerEfficiency'] = seq['hitEfficiency']
+
+        elif seq['className'] == "ldmx::TriggerProcessor" :
+            config_dict['TriggerThreshold'] = seq['threshold']
+            config_dict['TriggerEcalEndLayer'] = seq['end_layer']
+            config_dict['TriggerEcalStartLayer'] = seq['start_layer']
+
+        elif seq['className'] == "ldmx::FindableTrackProcessor" :
+            config_dict['FindableTrackWasRun'] = 1
+        elif seq['className'] == "ldmx::TrackerVetoProcessor" :
+            config_dict['TrackerVetoWasRun'] = 1
+            
+    config_dict['IsRecon'] = isRecon
+                
+                
+#    print mjson['sequence'][0]['generators'][0]['position'][0]
+#    print config_dict
+    print(json.dumps(config_dict, indent = 4))
+    return config_dict
+
+
 def collect_meta(conf_dict, mac_dict):
     meta = {
         'IsSimulation': True,
-        'IsRecon': False
     }
     # conf
     for fromconf in ['Scope', 'SampleId', 'PhysicsProcess', 'DetectorVersion']:
@@ -230,7 +333,7 @@ def get_parser():
                         help='LDMX Production simulation macro-definition file')
     parser.add_argument('-j', '--json-metadata', action='store', default='rucio.metadata',
                         help='LDMX Production simulation JSON metadata file')
-    parser.add_argument('action', choices=['generate-mac', 'collect-metadata'],
+    parser.add_argument('action', choices=['generate-mac', 'collect-metadata', 'test'],
                         help='Helper action to perform')
     return parser
 
@@ -242,7 +345,7 @@ if __name__ == '__main__':
     logger.setLevel(loglevel)
 
     # config is parsed for any action
-    conf_dict = parse_ldmx_config(cmd_args.config)
+#    conf_dict = parse_ldmx_config(cmd_args.config)
 
     # template substitution (RTE stage 1)
     if cmd_args.action == 'generate-mac':
@@ -251,6 +354,8 @@ if __name__ == '__main__':
         assemble_mac(mac_dict, cmd_args.mac)
         # print values for bash eval
         print_eval(conf_dict)
+    elif cmd_args.action == 'test' :
+        collect_from_json( "metadata_ldmx_v12_ecal_pn_run0.json" )
     elif cmd_args.action == 'collect-metadata':
         mac_dict = parse_mac(cmd_args.mac)
         meta = collect_meta(conf_dict, mac_dict)

--- a/src/act/ldmx/scripts/metadata_ldmx_v12_ecal_pn_run0.json
+++ b/src/act/ldmx/scripts/metadata_ldmx_v12_ecal_pn_run0.json
@@ -1,0 +1,232 @@
+{
+    "passName": "sim",
+    "maxEvents": 2,
+    "run": -1,
+    "inputFiles": [],
+    "outputFiles": [
+        "ldmx_v12_ecal_pn_run.root"
+    ],
+    "sequence": [
+        {
+            "className": "ldmx::Simulator",
+            "generators": [
+                {
+                    "class_name": "ldmx::ParticleGun",
+                    "time": 0.0,
+                    "particle": "e-",
+                    "energy": 4.0,
+                    "position": [
+                        -27.926,
+                        0,
+                        -700
+                    ],
+                    "direction": [
+                        0.07845909572784494,
+                        0,
+                        0.996917333733128
+                    ]
+                }
+            ],
+            "detector": "/Users/lenebryngemark/work/LDMX/code/ldmx-sw/install/data/detectors/ldmx-det-v12/detector.gdml",
+            "runNumber": 0,
+            "description": "ECal photo-nuclear, xsec bias 450",
+            "scoringPlanes": "/Users/lenebryngemark/work/LDMX/code/ldmx-sw/install/data/detectors/ldmx-det-v12/scoring_planes.gdml",
+            "randomSeeds": [
+                1,
+                2
+            ],
+            "beamSpotSmear": [
+                20.0,
+                80.0,
+                0
+            ],
+            "enableHitContribs": true,
+            "compressHitContribs": true,
+            "preInitCommands": [],
+            "postInitCommands": [],
+            "actions": [
+                {
+                    "class_name": "ldmx::TaggerVetoFilter",
+                    "threshold": 3800.0
+                },
+                {
+                    "class_name": "ldmx::TargetBremFilter",
+                    "recoil_max_p_threshold": 1500.0,
+                    "brem_min_energy_threshold": 2500.0,
+                    "kill_recoil_track": false
+                },
+                {
+                    "class_name": "ldmx::EcalProcessFilter",
+                    "process": "photonNuclear"
+                },
+                {
+                    "class_name": "ldmx::TrackProcessFilter",
+                    "process": "photonNuclear"
+                }
+            ],
+            "logging_prefix": "",
+            "rootPrimaryGenUseSeed": false,
+            "validate_detector": false,
+            "biasing_enabled": true,
+            "biasing_process": "photonNuclear",
+            "biasing_volume": "ecal",
+            "biasing_particle": "gamma",
+            "biasing_all": true,
+            "biasing_incident": true,
+            "biasing_disableEMBiasing": false,
+            "biasing_threshold": 2500.0,
+            "biasing_factor": 450,
+            "APrimeMass": 0.0,
+            "darkbrem_madgraphfilepath": "",
+            "darkbrem_method": 0,
+            "darkbrem_globalxsecfactor": 1.0
+        },
+        {
+            "className": "ldmx::EcalDigiProducer",
+            "gain": 2000.0,
+            "pedestal": 1100.0,
+            "noiseIntercept": 700.0,
+            "noiseSlope": 25.0,
+            "padCapacitance": 0.1,
+            "readoutThreshold": 4.0,
+            "makeConfigHists": false,
+            "nADCs": 10,
+            "iSOI": 0
+        },
+        {
+            "className": "ldmx::EcalRecProducer",
+            "digiCollName": "EcalDigis",
+            "digiPassName": "",
+            "secondOrderEnergyCorrection": 0.9975062344139651,
+            "layerWeights": [
+                1.675,
+                2.724,
+                4.398,
+                6.039,
+                7.696,
+                9.077,
+                9.63,
+                9.63,
+                9.63,
+                9.63,
+                9.63,
+                9.63,
+                9.63,
+                9.63,
+                9.63,
+                9.63,
+                9.63,
+                9.63,
+                9.63,
+                9.63,
+                9.63,
+                9.63,
+                9.63,
+                13.497,
+                17.364,
+                17.364,
+                17.364,
+                17.364,
+                17.364,
+                17.364,
+                17.364,
+                17.364,
+                17.364,
+                8.99
+            ]
+        },
+        {
+            "className": "ldmx::EcalVetoProcessor",
+            "num_ecal_layers": 34,
+            "do_bdt": true,
+            "bdt_file": "/Users/lenebryngemark/work/LDMX/code/ldmx-sw/install/data/Ecal/gabrielle.onnx",
+            "cellxy_file": "/Users/lenebryngemark/work/LDMX/code/ldmx-sw/install/data/Ecal/cellxy.txt",
+            "disc_cut": 0.99,
+            "collection_name": "EcalVeto"
+        },
+        {
+            "className": "ldmx::HcalDigiProducer",
+            "meanNoise": 0.02,
+            "readoutThreshold": 1,
+            "strips_side_lr_per_layer": 12,
+            "num_side_lr_hcal_layers": 26,
+            "strips_side_tb_per_layer": 12,
+            "num_side_tb_hcal_layers": 28,
+            "strips_back_per_layer": 60,
+            "num_back_hcal_layers": 96,
+            "super_strip_size": 1,
+            "mev_per_mip": 4.66,
+            "pe_per_mip": 68.0,
+            "strip_attenuation_length": 5.0,
+            "strip_position_resolution": 150.0,
+            "sim_hit_pass_name": "",
+            "randomSeed": 1593562860
+        },
+        {
+            "className": "ldmx::HcalVetoProcessor",
+            "pe_threshold": 5.0,
+            "max_time": 50.0,
+            "max_depth": 4000.0,
+            "back_min_pe": 1.0
+        },
+        {
+            "className": "ldmx::TrigScintDigiProducer",
+            "mean_noise": 0.02,
+            "number_of_strips": 50,
+            "number_of_arrays": 1,
+            "mev_per_mip": 0.4,
+            "pe_per_mip": 10.0,
+            "input_collection": "TriggerPadUpSimHits",
+            "input_pass_name": "",
+            "output_collection": "trigScintDigisUp",
+            "randomSeed": 1593562860
+        },
+        {
+            "className": "ldmx::TrigScintDigiProducer",
+            "mean_noise": 0.02,
+            "number_of_strips": 50,
+            "number_of_arrays": 1,
+            "mev_per_mip": 0.4,
+            "pe_per_mip": 10.0,
+            "input_collection": "TriggerPadTaggerSimHits",
+            "input_pass_name": "",
+            "output_collection": "trigScintDigisTag",
+            "randomSeed": 1593562860
+        },
+        {
+            "className": "ldmx::TrigScintDigiProducer",
+            "mean_noise": 0.02,
+            "number_of_strips": 50,
+            "number_of_arrays": 1,
+            "mev_per_mip": 0.4,
+            "pe_per_mip": 10.0,
+            "input_collection": "TriggerPadDownSimHits",
+            "input_pass_name": "",
+            "output_collection": "trigScintDigisDn",
+            "randomSeed": 1593562860
+        },
+        {
+            "className": "ldmx::TrackerHitKiller",
+            "hitEfficiency": 99.0
+        },
+        {
+            "className": "ldmx::TriggerProcessor",
+            "threshold": 1500.0,
+            "mode": 0,
+            "start_layer": 1,
+            "end_layer": 20
+        },
+        {
+            "className": "ldmx::FindableTrackProcessor"
+        },
+        {
+            "className": "ldmx::TrackerVetoProcessor"
+        }
+    ],
+    "keep": [],
+    "skimDefaultIsKeep": true,
+    "skimRules": [],
+    "logFrequency": 1,
+    "compressionSetting": 9,
+    "histogramFile": ""
+}


### PR DESCRIPTION
This adds the needed mapping from metadata dumping file (here, with name hardwired to the example file but this should be set in the job to something, much like the output file just gets a generic name), which is a json file, to the flat structure of the rucio listing. 

There still needs to be a final connection from this function to the collection from different parts. But this function replaces everything that was previously collected from the mac file, which won't be used any more. 

The new input script depends heavily on hidden defaults, which may well change with time. Thus, a function to dump all settable parameters has been added, to expose the settings. This dump is then what is parsed by the collect_from_json() function.

