### PR TITLE
Add batch ID to output directory structure 

### DIFF
--- a/src/act/ldmx/aCTLDMX2Arc.py
+++ b/src/act/ldmx/aCTLDMX2Arc.py
@@ -68,8 +68,8 @@ class aCTLDMX2Arc(aCTLDMXProcess):
         xrsl['executable'] = f"(executable = {os.path.basename(wrapper)})"
         xrsl['inputfiles'] = f'(inputfiles = ({os.path.basename(wrapper)} {wrapper}) \
                                              (ldmxjob.config {descriptionfile}) \
-                                             (ldmxsim.mac {templatefile}) \
-                                             (ldmxsim.mac.template {templatefile}) \
+                                             (ldmxjob.py {templatefile}) \
+                                             (ldmxjob.py.tpl {templatefile}) \
                                              (ldmx-simprod-rte-helper.py {self.conf.get(["executable", "ruciohelper"])}))'
         xrsl['stdout'] = '(stdout = stdout)'
         xrsl['gmlog'] = '(gmlog = gmlog)'

--- a/src/act/ldmx/aCTLDMXGetJobs.py
+++ b/src/act/ldmx/aCTLDMXGetJobs.py
@@ -20,12 +20,10 @@ class aCTLDMXGetJobs(aCTLDMXProcess):
         njobs = int(config['NumberofJobs'])
         self.log.info(f'Creating {njobs} jobs')
         for n in range(njobs):
-            config['RandomSeed1'] = randomseed1
-            config['RandomSeed2'] = randomseed2
-            config['runNumber'] = n+1
+            config['RandomSeed1'] = randomseed1+n
+            config['RandomSeed2'] = randomseed2+n
+            config['runNumber']   = randomseed1+n
             yield config
-            randomseed1 += 1
-            randomseed2 += 1
 
     def getNewJobs(self):
         '''
@@ -83,13 +81,13 @@ class aCTLDMXGetJobs(aCTLDMXProcess):
                     with tempfile.NamedTemporaryFile(mode='w', prefix=f'{newtemplatefile}.', delete=False, encoding='utf-8') as ntf:
                         newtemplatefile = ntf.name
                         for l in template:
-                            if l.startswith('/ldmx/persistency/root/runNumber '):
-                                ntf.write(f'/ldmx/persistency/root/runNumber {jobconfig["runNumber"]}\n')
-                            elif l.startswith('/random/setSeeds '):
-                                ntf.write(f'/random/setSeeds {jobconfig["RandomSeed1"]} {jobconfig["RandomSeed2"]}\n')
+                            if l.startswith('sim.runNumber'):
+                                ntf.write(f'sim.runNumber = {jobconfig["runNumber"]}\n')
+                            elif l.startswith('sim.randomSeeds'):
+                                ntf.write(f'sim.randomSeeds = [ {jobconfig["RandomSeed1"]}, {jobconfig["RandomSeed2"]} ]\n')
                             else:
                                 ntf.write(l)
-
+                                
                     self.dbldmx.insertJob(newjobfile, newtemplatefile, proxyid, batchid=batchid)
                     self.log.info(f'Inserted job from {newjobfile} into DB')
             except Exception as e:

--- a/src/act/ldmx/scripts/ldmx-simprod-rte-helper.py
+++ b/src/act/ldmx/scripts/ldmx-simprod-rte-helper.py
@@ -44,6 +44,11 @@ def parse_ldmx_config(config='ldmxjob.config'):
     # ensure FileName is set to something
     if 'FileName' not in conf_dict:
         conf_dict['FileName'] = 'output.root'
+    #batch id will be used for storage directory structure. Should always be set.
+    if 'BatchID' not in conf_dict:
+        logger.error('BatchID is not defined in the %s. Needed for storage directory structure. Job aborted.', config)
+        sys.exit(1)
+        
     return conf_dict
 
 
@@ -189,7 +194,7 @@ def collect_meta(conf_dict, json_file):
 
     # conf
     meta['IsSimulation'] = True
-    for fromconf in ['Scope', 'SampleId', 'PhysicsProcess', 'DetectorVersion']:
+    for fromconf in ['Scope', 'SampleId', 'BatchID', 'PhysicsProcess', 'DetectorVersion']:
         meta[fromconf] = conf_dict[fromconf] if fromconf in conf_dict else None
     meta['ElectronNumber'] = int(conf_dict['ElectronNumber']) if 'ElectronNumber' in conf_dict else None
     meta['MagneticFieldmap'] = conf_dict['FieldMap'] if 'FieldMap' in conf_dict else None
@@ -200,7 +205,7 @@ def collect_meta(conf_dict, json_file):
     meta['Walltime'] = meta['FileCreationTime'] - job_starttime()
     
     data_location = os.environ['LDMX_STORAGE_BASE']
-    data_location += '/ldmx/mc-data/v{DetectorVersion}/{BeamEnergy}GeV/mc_{SampleId}_t{FileCreationTime}.root'.format(**meta)
+    data_location += '/ldmx/mc-data/v{DetectorVersion}/{BeamEnergy}GeV/{BatchID}/mc_{SampleId}_t{FileCreationTime}.root'.format(**meta)
     meta['DataLocation'] = data_location
 
     # Rucio metadata


### PR DESCRIPTION
BatchID gets read from the production config, and if it's not set, throws an error. 