### PR TITLE
Adapt to new ownership and name of run number

### DIFF
--- a/src/act/ldmx/aCTLDMXGetJobs.py
+++ b/src/act/ldmx/aCTLDMXGetJobs.py
@@ -83,6 +83,8 @@ class aCTLDMXGetJobs(aCTLDMXProcess):
                         for l in template:
                             if l.startswith('sim.runNumber'):
                                 ntf.write(f'sim.runNumber = {jobconfig["runNumber"]}\n')
+                            elif l.startswith('p.run'):
+                                ntf.write(f'p.run = {jobconfig["runNumber"]}\n')
                             elif l.startswith('sim.randomSeeds'):
                                 ntf.write(f'sim.randomSeeds = [ {jobconfig["RandomSeed1"]}, {jobconfig["RandomSeed2"]} ]\n')
                             else:


### PR DESCRIPTION
The run number parameter is now owned by the process ("p") and not the simulator ("sim"); also the name has changed from `runNumber` to `run`. Added this as a case in the template copying/substitution.

I changed this on the fly on the aCT machine but it needs to get fixed here too, of course. 